### PR TITLE
Commenting out ShippingOptionExpiredError

### DIFF
--- a/packages/core/src/app/checkout/CheckoutNew.tsx
+++ b/packages/core/src/app/checkout/CheckoutNew.tsx
@@ -35,7 +35,7 @@ import { getSupportedMethodIds } from '../customer/getSupportedMethods';
 import { EmbeddedCheckoutStylesheet, isEmbedded } from '../embeddedCheckout';
 import { PromotionBannerList } from '../promotion';
 import { hasSelectedShippingOptions, isUsingMultiShipping } from '../shipping';
-import { ShippingOptionExpiredError } from '../shipping/shippingOption';
+// import { ShippingOptionExpiredError } from '../shipping/shippingOption';
 import { LazyContainer } from '../ui/loading';
 import { BillingStep } from './BillingStep/BillingStep';
 import { CheckoutPageFallback } from './CheckoutPageFallback/CheckoutPageFallback';
@@ -528,7 +528,7 @@ class Checkout extends Component<
       isShippingStepFinished
     ) {
       this.navigateToStep(CheckoutStepType.Shipping);
-      this.setState({ error: new ShippingOptionExpiredError() });
+      // this.setState({ error: new ShippingOptionExpiredError() });
     }
 
     this.setState({ hasSelectedShippingOptions: newHasSelectedShippingOptions });


### PR DESCRIPTION
This PR removes a popover that was showing up when a free shipping coupon was applied. Just commenting it out for now, we don't want it to appear.

![image](https://github.com/user-attachments/assets/0ab44b4f-75bf-44d0-b422-420f647f2a96)
