### PR TITLE
Checkout: bootstrap ibc_* values from URL params into cookies

### DIFF
--- a/packages/core/src/app/checkout/renderCheckout.tsx
+++ b/packages/core/src/app/checkout/renderCheckout.tsx
@@ -13,6 +13,25 @@ export default function renderCheckout({
     publicPath,
     ...props
 }: RenderCheckoutOptions): void {
+    // The Next.js storefront propagates ibc_newCheckoutId / ibc_isParent as
+    // query params on the BigCommerce SSO redirect because cross-domain
+    // cookie writes from ignatiusbookclub.com to .ignatiusbookfairs.com are
+    // silently dropped by the browser. Mirror them into cookies here — before
+    // CheckoutApp is required and the React tree mounts — so existing readers
+    // (useCookies in CheckoutApp.tsx) pick them up unchanged. URL params are
+    // left in place so a re-init can read them again.
+    if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search);
+
+        (['ibc_newCheckoutId', 'ibc_isParent'] as const).forEach((name) => {
+            const value = params.get(name);
+
+            if (value !== null) {
+                document.cookie = `${name}=${encodeURIComponent(value)}; path=/; domain=.ignatiusbookfairs.com; SameSite=Lax`;
+            }
+        });
+    }
+
     const configuredPublicPath = configurePublicPath(publicPath);
 
     // We want to use `require` here because we want to set up the public path


### PR DESCRIPTION
Next.js now passes ibc_newCheckoutId and ibc_isParent as query params on the BC SSO redirect because cross-domain cookie writes to .ignatiusbookfairs.com are dropped on production.

- Read both params from window.location.search at the top of renderCheckout, before CheckoutApp loads and React mounts.
- Mirror them into document.cookie so existing useCookies readers in CheckoutApp.tsx pick them up unchanged.
- Leave URL params intact for re-init; fall back to existing behavior when missing.
