### PR TITLE
Checkout: read ibc_* from URL fragment and clean address bar

### DIFF
--- a/packages/core/src/app/checkout/renderCheckout.tsx
+++ b/packages/core/src/app/checkout/renderCheckout.tsx
@@ -22,19 +22,14 @@ export default function renderCheckout({
     // fragment is preserved across 302s when the Location has no fragment of
     // its own. Mirror them into cookies here — before CheckoutApp is required
     // and the React tree mounts — so existing readers (useCookies in
-    // CheckoutApp.tsx) pick them up unchanged. Search is kept as a fallback
-    // for paths where BC happens to preserve query params.
+    // CheckoutApp.tsx) pick them up unchanged. Once written, strip just our
+    // two keys from the URL via replaceState so the address bar stays clean;
+    // any other fragment/query content is preserved.
     if (typeof window !== 'undefined') {
         const searchParams = new URLSearchParams(window.location.search);
         const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
 
-        // eslint-disable-next-line no-console
-        console.log('🚀 ~ renderCheckout ~ ibc params:', {
-            search: window.location.search,
-            hash: window.location.hash,
-            ibc_newCheckoutId: hashParams.get('ibc_newCheckoutId') ?? searchParams.get('ibc_newCheckoutId'),
-            ibc_isParent: hashParams.get('ibc_isParent') ?? searchParams.get('ibc_isParent'),
-        });
+        let consumedFromUrl = false;
 
         (['ibc_newCheckoutId', 'ibc_isParent'] as const).forEach((name) => {
             const value = hashParams.get(name) ?? searchParams.get(name);
@@ -42,7 +37,28 @@ export default function renderCheckout({
             if (value !== null) {
                 document.cookie = `${name}=${encodeURIComponent(value)}; path=/; SameSite=Lax`;
             }
+
+            if (hashParams.has(name)) {
+                hashParams.delete(name);
+                consumedFromUrl = true;
+            }
+
+            if (searchParams.has(name)) {
+                searchParams.delete(name);
+                consumedFromUrl = true;
+            }
         });
+
+        if (consumedFromUrl) {
+            const remainingSearch = searchParams.toString();
+            const remainingHash = hashParams.toString();
+            const cleanedUrl =
+                window.location.pathname +
+                (remainingSearch ? `?${remainingSearch}` : '') +
+                (remainingHash ? `#${remainingHash}` : '');
+
+            window.history.replaceState(null, '', cleanedUrl);
+        }
     }
 
     const configuredPublicPath = configurePublicPath(publicPath);


### PR DESCRIPTION
BC's /cart.php?action=loadInCheckout strips unknown query params during its server-side 302 to /checkout, so query params don't survive the SSO hop. Fragments do (RFC 7231 §7.1.2), so Next.js now passes ibc_* on the SSO URL's fragment.

- Read ibc_newCheckoutId and ibc_isParent from window.location.hash, with search kept as a fallback.
- Drop the hardcoded domain= attribute on the cookie write so it works on any host (prod, staging, dev) — the reader is on the same page.
- Strip just our two keys via history.replaceState after cookies are written, preserving any other hash/query content.
