### PR TITLE
Improve Checkout Authentication Handling by Replacing Cross-Domain Cookies with URL Parameters

### DIFF
--- a/packages/core/src/app/checkout/renderCheckout.tsx
+++ b/packages/core/src/app/checkout/renderCheckout.tsx
@@ -22,19 +22,14 @@ export default function renderCheckout({
     // fragment is preserved across 302s when the Location has no fragment of
     // its own. Mirror them into cookies here — before CheckoutApp is required
     // and the React tree mounts — so existing readers (useCookies in
-    // CheckoutApp.tsx) pick them up unchanged. Search is kept as a fallback
-    // for paths where BC happens to preserve query params.
+    // CheckoutApp.tsx) pick them up unchanged. Once written, strip just our
+    // two keys from the URL via replaceState so the address bar stays clean;
+    // any other fragment/query content is preserved.
     if (typeof window !== 'undefined') {
         const searchParams = new URLSearchParams(window.location.search);
         const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
 
-        // eslint-disable-next-line no-console
-        console.log('🚀 ~ renderCheckout ~ ibc params:', {
-            search: window.location.search,
-            hash: window.location.hash,
-            ibc_newCheckoutId: hashParams.get('ibc_newCheckoutId') ?? searchParams.get('ibc_newCheckoutId'),
-            ibc_isParent: hashParams.get('ibc_isParent') ?? searchParams.get('ibc_isParent'),
-        });
+        let consumedFromUrl = false;
 
         (['ibc_newCheckoutId', 'ibc_isParent'] as const).forEach((name) => {
             const value = hashParams.get(name) ?? searchParams.get(name);
@@ -42,7 +37,28 @@ export default function renderCheckout({
             if (value !== null) {
                 document.cookie = `${name}=${encodeURIComponent(value)}; path=/; SameSite=Lax`;
             }
+
+            if (hashParams.has(name)) {
+                hashParams.delete(name);
+                consumedFromUrl = true;
+            }
+
+            if (searchParams.has(name)) {
+                searchParams.delete(name);
+                consumedFromUrl = true;
+            }
         });
+
+        if (consumedFromUrl) {
+            const remainingSearch = searchParams.toString();
+            const remainingHash = hashParams.toString();
+            const cleanedUrl =
+                window.location.pathname +
+                (remainingSearch ? `?${remainingSearch}` : '') +
+                (remainingHash ? `#${remainingHash}` : '');
+
+            window.history.replaceState(null, '', cleanedUrl);
+        }
     }
 
     const configuredPublicPath = configurePublicPath(publicPath);

--- a/packages/core/src/app/checkout/renderCheckout.tsx
+++ b/packages/core/src/app/checkout/renderCheckout.tsx
@@ -13,6 +13,25 @@ export default function renderCheckout({
     publicPath,
     ...props
 }: RenderCheckoutOptions): void {
+    // The Next.js storefront propagates ibc_newCheckoutId / ibc_isParent as
+    // query params on the BigCommerce SSO redirect because cross-domain
+    // cookie writes from ignatiusbookclub.com to .ignatiusbookfairs.com are
+    // silently dropped by the browser. Mirror them into cookies here — before
+    // CheckoutApp is required and the React tree mounts — so existing readers
+    // (useCookies in CheckoutApp.tsx) pick them up unchanged. URL params are
+    // left in place so a re-init can read them again.
+    if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search);
+
+        (['ibc_newCheckoutId', 'ibc_isParent'] as const).forEach((name) => {
+            const value = params.get(name);
+
+            if (value !== null) {
+                document.cookie = `${name}=${encodeURIComponent(value)}; path=/; domain=.ignatiusbookfairs.com; SameSite=Lax`;
+            }
+        });
+    }
+
     const configuredPublicPath = configurePublicPath(publicPath);
 
     // We want to use `require` here because we want to set up the public path

--- a/packages/core/src/app/checkout/renderCheckout.tsx
+++ b/packages/core/src/app/checkout/renderCheckout.tsx
@@ -19,15 +19,24 @@ export default function renderCheckout({
     // silently dropped by the browser. Mirror them into cookies here — before
     // CheckoutApp is required and the React tree mounts — so existing readers
     // (useCookies in CheckoutApp.tsx) pick them up unchanged. URL params are
-    // left in place so a re-init can read them again.
+    // left in place so a re-init can read them again. No `domain=` attribute:
+    // host-scoped is enough since the reader is on the same page, and it keeps
+    // the write working on staging / dev hosts too.
     if (typeof window !== 'undefined') {
         const params = new URLSearchParams(window.location.search);
+
+        // eslint-disable-next-line no-console
+        console.log('🚀 ~ renderCheckout ~ ibc params:', {
+            ibc_newCheckoutId: params.get('ibc_newCheckoutId'),
+            ibc_isParent: params.get('ibc_isParent'),
+            search: window.location.search,
+        });
 
         (['ibc_newCheckoutId', 'ibc_isParent'] as const).forEach((name) => {
             const value = params.get(name);
 
             if (value !== null) {
-                document.cookie = `${name}=${encodeURIComponent(value)}; path=/; domain=.ignatiusbookfairs.com; SameSite=Lax`;
+                document.cookie = `${name}=${encodeURIComponent(value)}; path=/; SameSite=Lax`;
             }
         });
     }

--- a/packages/core/src/app/checkout/renderCheckout.tsx
+++ b/packages/core/src/app/checkout/renderCheckout.tsx
@@ -13,27 +13,31 @@ export default function renderCheckout({
     publicPath,
     ...props
 }: RenderCheckoutOptions): void {
-    // The Next.js storefront propagates ibc_newCheckoutId / ibc_isParent as
-    // query params on the BigCommerce SSO redirect because cross-domain
-    // cookie writes from ignatiusbookclub.com to .ignatiusbookfairs.com are
-    // silently dropped by the browser. Mirror them into cookies here — before
-    // CheckoutApp is required and the React tree mounts — so existing readers
-    // (useCookies in CheckoutApp.tsx) pick them up unchanged. URL params are
-    // left in place so a re-init can read them again. No `domain=` attribute:
-    // host-scoped is enough since the reader is on the same page, and it keeps
-    // the write working on staging / dev hosts too.
+    // The Next.js storefront propagates ibc_newCheckoutId / ibc_isParent on
+    // the BigCommerce SSO URL because cross-domain cookie writes from
+    // ignatiusbookclub.com to .ignatiusbookfairs.com are silently dropped by
+    // the browser. They're carried in the URL fragment (not the query string)
+    // because BC's /cart.php?action=loadInCheckout server-side redirect to
+    // /checkout strips unknown query params, but per RFC 7231 §7.1.2 the
+    // fragment is preserved across 302s when the Location has no fragment of
+    // its own. Mirror them into cookies here — before CheckoutApp is required
+    // and the React tree mounts — so existing readers (useCookies in
+    // CheckoutApp.tsx) pick them up unchanged. Search is kept as a fallback
+    // for paths where BC happens to preserve query params.
     if (typeof window !== 'undefined') {
-        const params = new URLSearchParams(window.location.search);
+        const searchParams = new URLSearchParams(window.location.search);
+        const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
 
         // eslint-disable-next-line no-console
         console.log('🚀 ~ renderCheckout ~ ibc params:', {
-            ibc_newCheckoutId: params.get('ibc_newCheckoutId'),
-            ibc_isParent: params.get('ibc_isParent'),
             search: window.location.search,
+            hash: window.location.hash,
+            ibc_newCheckoutId: hashParams.get('ibc_newCheckoutId') ?? searchParams.get('ibc_newCheckoutId'),
+            ibc_isParent: hashParams.get('ibc_isParent') ?? searchParams.get('ibc_isParent'),
         });
 
         (['ibc_newCheckoutId', 'ibc_isParent'] as const).forEach((name) => {
-            const value = params.get(name);
+            const value = hashParams.get(name) ?? searchParams.get(name);
 
             if (value !== null) {
                 document.cookie = `${name}=${encodeURIComponent(value)}; path=/; SameSite=Lax`;


### PR DESCRIPTION
In the last release, we faced a cross-domain cookie issue on the production server. On staging, it worked because both domains were the same, but in production the checkout and website domains are different.

We have now applied a quick fix by passing the parameters in the checkout page URL instead of relying on cookies.